### PR TITLE
feat(CutsceneLibrary) Save methods for ZkCutsceneLibrary

### DIFF
--- a/include/zenkit-capi/Archive.h
+++ b/include/zenkit-capi/Archive.h
@@ -1,0 +1,9 @@
+// Copyright © 2023. GothicKit Contributors
+// SPDX-License-Identifier: MIT
+#pragma once
+
+typedef enum {
+	ZkArchiveFormat_BINARY = 0,
+	ZkArchiveFormat_BINSAFE = 1,
+	ZkArchiveFormat_ASCII = 2,
+} ZkArchiveFormat;

--- a/include/zenkit-capi/CutsceneLibrary.h
+++ b/include/zenkit-capi/CutsceneLibrary.h
@@ -1,6 +1,7 @@
 // Copyright © 2023. GothicKit Contributors
 // SPDX-License-Identifier: MIT
 #pragma once
+#include "Archive.h"
 #include "Library.h"
 #include "Stream.h"
 #include "Vfs.h"
@@ -21,6 +22,10 @@ typedef ZkBool (*ZkCutsceneBlockEnumerator)(void* ctx, ZkCutsceneBlock const* bl
 ZKC_API ZkCutsceneLibrary* ZkCutsceneLibrary_load(ZkRead* buf);
 ZKC_API ZkCutsceneLibrary* ZkCutsceneLibrary_loadPath(ZkString path);
 ZKC_API ZkCutsceneLibrary* ZkCutsceneLibrary_loadVfs(ZkVfs const* vfs, ZkString string);
+
+ZKC_API void ZkCutsceneLibrary_save(ZkCutsceneLibrary* slf, ZkWrite* buf, ZkArchiveFormat fmt);
+ZKC_API void ZkCutsceneLibrary_savePath(ZkCutsceneLibrary* slf, ZkString path, ZkArchiveFormat fmt);
+
 ZKC_API void ZkCutsceneLibrary_del(ZkCutsceneLibrary* slf);
 
 ZKC_API ZkSize ZkCutsceneLibrary_getBlockCount(ZkCutsceneLibrary const* slf);

--- a/include/zenkit-capi/Stream.h
+++ b/include/zenkit-capi/Stream.h
@@ -8,8 +8,10 @@
 #ifdef __cplusplus
 	#include <zenkit/Stream.hh>
 using ZkRead = zenkit::Read;
+using ZkWrite = zenkit::Write;
 #else
 typedef struct ZkInternal_Read ZkRead;
+typedef struct ZkInternal_Write ZkWrite;
 #endif
 
 typedef enum {
@@ -34,3 +36,16 @@ ZKC_API void ZkRead_del(ZkRead* slf);
 
 ZKC_API ZkSize ZkRead_getSize(ZkRead* slf);
 ZKC_API ZkSize ZkRead_getBytes(ZkRead* slf, void* buf, ZkSize length);
+
+typedef struct {
+	ZkSize (*write)(void* ctx, void const* buf, ZkSize len);
+	ZkSize (*seek)(void* ctx, ZkOffset off, ZkWhence whence);
+	ZkSize (*tell)(void const* ctx);
+	void (*del)(void const* ctx);
+} ZkWriteExt;
+
+ZKC_API ZkWrite* ZkWrite_newFile(FILE* stream);
+ZKC_API ZkWrite* ZkWrite_newMem(ZkByte* bytes, ZkSize length);
+ZKC_API ZkWrite* ZkWrite_newPath(ZkString path);
+ZKC_API ZkWrite* ZkWrite_newExt(ZkWriteExt ext, void* ctx);
+ZKC_API void ZkWrite_del(ZkWrite* slf);

--- a/src/CutsceneLibrary.cc
+++ b/src/CutsceneLibrary.cc
@@ -7,6 +7,8 @@
 ZKC_LOADER(ZkCutsceneLibrary);
 ZKC_PATH_LOADER(ZkCutsceneLibrary);
 ZKC_VFS_LOADER(ZkCutsceneLibrary);
+ZKC_SAVER(ZkCutsceneLibrary);
+ZKC_PATH_SAVER(ZkCutsceneLibrary);
 ZKC_DELETER(ZkCutsceneLibrary);
 
 ZkSize ZkCutsceneLibrary_getBlockCount(ZkCutsceneLibrary const* slf) {

--- a/src/Internal.hh
+++ b/src/Internal.hh
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 #include <zenkit/Archive.hh>
+#include "zenkit-capi/Archive.h"
 
 #define ZKC_LOADER(cls)                                                                                                \
 	cls* cls##_load(ZkRead* buf) {                                                                                     \
@@ -51,6 +52,37 @@
                                                                                                                        \
 		auto rd = node->open_read();                                                                                   \
 		return cls##_load(rd.get());                                                                                   \
+	}
+
+#define ZKC_SAVER(cls)                                                                                                 \
+	void cls##_save(cls* slf, ZkWrite* buf, ZkArchiveFormat fmt) {                                                     \
+		if (buf == nullptr) {                                                                                          \
+			ZKC_LOG_WARN_NULL(#cls "_save");                                                                           \
+			return;                                                                                                    \
+		}                                                                                                              \
+                                                                                                                       \
+		try {                                                                                                          \
+          	slf->save(buf, static_cast<zenkit::ArchiveFormat>(fmt));                                                   \
+		} catch (std::exception const& exc) {                                                                          \
+			ZKC_LOG_ERROR(#cls "_save() failed: %s", exc.what());                                                      \
+			return;                                                                                                    \
+		}                                                                                                              \
+	}
+
+#define ZKC_PATH_SAVER(cls)                                                                                            \
+	void cls##_savePath(cls* slf, ZkString path, ZkArchiveFormat fmt) {                                                \
+		if (path == nullptr) {                                                                                         \
+			ZKC_LOG_WARN_NULL(#cls "_savePath");                                                                       \
+			return;                                                                                                    \
+		}                                                                                                              \
+                                                                                                                       \
+		try {                                                                                                          \
+            auto buf = zenkit::Write::to(path);                                                                        \
+            slf->save(buf.get(), static_cast<zenkit::ArchiveFormat>(fmt));                                             \
+		} catch (std::exception const& exc) {                                                                          \
+			ZKC_LOG_ERROR(#cls "_savePath() failed: %s", exc.what());                                                  \
+			return;                                                                                                    \
+		}                                                                                                              \
 	}
 
 #define ZKC_DELETER(cls)                                                                                               \


### PR DESCRIPTION
First commit adds missing ZkWrite API, and the second one makes use of it in ZkCutsceneLibrary save methods. 